### PR TITLE
WEA-32 Implement deletable interfaces for Realm models to enforce cascade deletion

### DIFF
--- a/app/src/main/java/com/ayush/weatherapp/home/HomeActivity.java
+++ b/app/src/main/java/com/ayush/weatherapp/home/HomeActivity.java
@@ -294,6 +294,7 @@ public class HomeActivity extends MVPBaseActivity<HomePresenterImpl>
     if (EasyPermissions.somePermissionPermanentlyDenied(this, perms)) {
       new AppSettingsDialog.Builder(this).build().show();
     } else {
+      Toast.makeText(this, "Location permission not granted", Toast.LENGTH_SHORT).show();
       finish();
     }
   }

--- a/app/src/main/java/com/ayush/weatherapp/mapper/ForecastDTOtoRealmMapper.java
+++ b/app/src/main/java/com/ayush/weatherapp/mapper/ForecastDTOtoRealmMapper.java
@@ -42,13 +42,6 @@ public final class ForecastDTOtoRealmMapper {
     currentForecast.setSummary(dto.getSummary());
     currentForecast.setIcon(dto.getIcon());
     currentForecast.setTemperature(dto.getTemperature());
-    currentForecast.setApparentTemperature(dto.getApparentTemperature());
-    currentForecast.setDewPoint(dto.getDewPoint());
-    currentForecast.setHumidity(dto.getHumidity());
-    currentForecast.setPressure(dto.getHumidity());
-    currentForecast.setPressure(dto.getPressure());
-    currentForecast.setWindSpeed(dto.getWindSpeed());
-    currentForecast.setVisibility(dto.getVisibility());
 
     return currentForecast;
   }
@@ -92,8 +85,6 @@ public final class ForecastDTOtoRealmMapper {
     dailyData.setSunsetTime(dto.getSunsetTime());
     dailyData.setTemperatureHigh(dto.getTemperatureHigh());
     dailyData.setTemperatureLow(dto.getTemperatureLow());
-    dailyData.setApparentTemperatureHigh(dto.getApparentTemperatureHigh());
-    dailyData.setApparentTemperatureLow(dto.getApparentTemperatureLow());
     dailyData.setWindSpeed(dto.getWindSpeed());
 
     return dailyData;
@@ -130,7 +121,6 @@ public final class ForecastDTOtoRealmMapper {
     hourlyData.setTime(dto.getTime());
     hourlyData.setSummary(dto.getSummary());
     hourlyData.setTemperature(dto.getTemperature());
-    hourlyData.setApparentTemperature(dto.getApparentTemperature());
 
     return hourlyData;
   }

--- a/app/src/main/java/com/ayush/weatherapp/mapper/ForecastRealmToEntityMapper.java
+++ b/app/src/main/java/com/ayush/weatherapp/mapper/ForecastRealmToEntityMapper.java
@@ -92,6 +92,8 @@ public final class ForecastRealmToEntityMapper {
     if (hourlyDatas == null || hourlyDatas.isEmpty()) {
       return null;
     }
+    //we need only six data for the hourly forecast
+    hourlyDatas = new ArrayList<>(hourlyDatas.subList(0, 6));
 
     List<HourlyDataEntity> entityList = new ArrayList<>(hourlyDatas.size());
 

--- a/app/src/main/java/com/ayush/weatherapp/mapper/GeocodingDTOToRealmMapper.java
+++ b/app/src/main/java/com/ayush/weatherapp/mapper/GeocodingDTOToRealmMapper.java
@@ -7,7 +7,6 @@ import com.ayush.weatherapp.retrofit.geocodingApi.pojo.AddressComponentsDTO;
 import com.ayush.weatherapp.retrofit.geocodingApi.pojo.AddressDTO;
 import com.ayush.weatherapp.retrofit.geocodingApi.pojo.GeoLocationDTO;
 import com.ayush.weatherapp.utils.DateUtils;
-import java.util.Date;
 import java.util.List;
 
 public final class GeocodingDTOToRealmMapper {
@@ -20,6 +19,10 @@ public final class GeocodingDTOToRealmMapper {
   }
 
   public static GeoLocation transform(GeoLocationDTO dto) {
+    if (dto.getAddressDTOS() == null || dto.getAddressDTOS().isEmpty()) {
+      return null;
+    }
+
     long primaryKey = RealmUtils.getMaxIdForPrimaryKey(GeoLocation.class);
     GeoLocation geoLocation = new GeoLocation(++primaryKey);
 

--- a/app/src/main/java/com/ayush/weatherapp/realm/RealmDeletable.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/RealmDeletable.java
@@ -1,0 +1,7 @@
+package com.ayush.weatherapp.realm;
+
+public interface RealmDeletable {
+
+  // should only be called from inside a realm transaction
+  void removeFromRealm();
+}

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/CurrentForecast.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/CurrentForecast.java
@@ -1,9 +1,10 @@
 package com.ayush.weatherapp.realm.model.forecast;
 
+import com.ayush.weatherapp.realm.RealmDeletable;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 
-public class CurrentForecast extends RealmObject {
+public class CurrentForecast extends RealmObject implements RealmDeletable {
 
   @PrimaryKey private long primaryKey;
   private long time;
@@ -106,5 +107,9 @@ public class CurrentForecast extends RealmObject {
 
   public void setVisibility(double visibility) {
     this.visibility = visibility;
+  }
+
+  @Override public void removeFromRealm() {
+    deleteFromRealm();
   }
 }

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/CurrentForecast.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/CurrentForecast.java
@@ -11,12 +11,6 @@ public class CurrentForecast extends RealmObject implements RealmDeletable {
   private String summary;
   private String icon;
   private double temperature;
-  private double apparentTemperature;
-  private double dewPoint;
-  private double humidity;
-  private double pressure;
-  private double windSpeed;
-  private double visibility;
 
   public CurrentForecast() {
   }
@@ -59,54 +53,6 @@ public class CurrentForecast extends RealmObject implements RealmDeletable {
 
   public void setTemperature(double temperature) {
     this.temperature = temperature;
-  }
-
-  public double getApparentTemperature() {
-    return apparentTemperature;
-  }
-
-  public void setApparentTemperature(double apparentTemperature) {
-    this.apparentTemperature = apparentTemperature;
-  }
-
-  public double getDewPoint() {
-    return dewPoint;
-  }
-
-  public void setDewPoint(double dewPoint) {
-    this.dewPoint = dewPoint;
-  }
-
-  public double getHumidity() {
-    return humidity;
-  }
-
-  public void setHumidity(double humidity) {
-    this.humidity = humidity;
-  }
-
-  public double getPressure() {
-    return pressure;
-  }
-
-  public void setPressure(double pressure) {
-    this.pressure = pressure;
-  }
-
-  public double getWindSpeed() {
-    return windSpeed;
-  }
-
-  public void setWindSpeed(double windSpeed) {
-    this.windSpeed = windSpeed;
-  }
-
-  public double getVisibility() {
-    return visibility;
-  }
-
-  public void setVisibility(double visibility) {
-    this.visibility = visibility;
   }
 
   @Override public void removeFromRealm() {

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/DailyData.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/DailyData.java
@@ -14,8 +14,6 @@ public class DailyData extends RealmObject implements RealmDeletable {
   private int sunsetTime;
   private double temperatureHigh;
   private double temperatureLow;
-  private double apparentTemperatureHigh;
-  private double apparentTemperatureLow;
   private double windSpeed;
 
   public DailyData() {
@@ -83,22 +81,6 @@ public class DailyData extends RealmObject implements RealmDeletable {
 
   public void setTemperatureLow(double temperatureLow) {
     this.temperatureLow = temperatureLow;
-  }
-
-  public double getApparentTemperatureHigh() {
-    return apparentTemperatureHigh;
-  }
-
-  public void setApparentTemperatureHigh(double apparentTemperatureHigh) {
-    this.apparentTemperatureHigh = apparentTemperatureHigh;
-  }
-
-  public double getApparentTemperatureLow() {
-    return apparentTemperatureLow;
-  }
-
-  public void setApparentTemperatureLow(double apparentTemperatureLow) {
-    this.apparentTemperatureLow = apparentTemperatureLow;
   }
 
   public double getWindSpeed() {

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/DailyData.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/DailyData.java
@@ -1,9 +1,10 @@
 package com.ayush.weatherapp.realm.model.forecast;
 
+import com.ayush.weatherapp.realm.RealmDeletable;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 
-public class DailyData extends RealmObject {
+public class DailyData extends RealmObject implements RealmDeletable {
 
   @PrimaryKey private long primaryKey;
   private long time;
@@ -106,5 +107,9 @@ public class DailyData extends RealmObject {
 
   public void setWindSpeed(double windSpeed) {
     this.windSpeed = windSpeed;
+  }
+
+  @Override public void removeFromRealm() {
+    deleteFromRealm();
   }
 }

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/DailyForecast.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/DailyForecast.java
@@ -1,11 +1,12 @@
 package com.ayush.weatherapp.realm.model.forecast;
 
+import com.ayush.weatherapp.realm.RealmDeletable;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 import java.util.List;
 
-public class DailyForecast extends RealmObject {
+public class DailyForecast extends RealmObject implements RealmDeletable {
 
   @PrimaryKey private long primaryKey;
   private String summary;
@@ -46,5 +47,14 @@ public class DailyForecast extends RealmObject {
   public void setDailyDataList(List<DailyData> dailyDataList) {
     this.dailyDataList = new RealmList<>();
     this.dailyDataList.addAll(dailyDataList);
+  }
+
+  @Override public void removeFromRealm() {
+    if (dailyDataList != null) {
+      for (DailyData dailyData : dailyDataList) {
+        dailyData.removeFromRealm();
+      }
+    }
+    deleteFromRealm();
   }
 }

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/DailyForecast.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/DailyForecast.java
@@ -50,9 +50,10 @@ public class DailyForecast extends RealmObject implements RealmDeletable {
   }
 
   @Override public void removeFromRealm() {
+    //todo ask subash
     if (dailyDataList != null) {
-      for (DailyData dailyData : dailyDataList) {
-        dailyData.removeFromRealm();
+      for (int i = dailyDataList.size() - 1; i >= 0; i--) {
+        dailyDataList.get(i).removeFromRealm();
       }
     }
     deleteFromRealm();

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/Forecast.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/Forecast.java
@@ -1,9 +1,10 @@
 package com.ayush.weatherapp.realm.model.forecast;
 
+import com.ayush.weatherapp.realm.RealmDeletable;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 
-public class Forecast extends RealmObject {
+public class Forecast extends RealmObject implements RealmDeletable {
 
   @PrimaryKey private long primaryKey;
   private CurrentForecast currentForecast;
@@ -53,5 +54,18 @@ public class Forecast extends RealmObject {
 
   public void setDailyForecast(DailyForecast dailyForecast) {
     this.dailyForecast = dailyForecast;
+  }
+
+  @Override public void removeFromRealm() {
+    if (currentForecast != null) {
+      currentForecast.removeFromRealm();
+    }
+    if (hourlyForecast != null) {
+      hourlyForecast.removeFromRealm();
+    }
+    if (dailyForecast != null) {
+      dailyForecast.removeFromRealm();
+    }
+    deleteFromRealm();
   }
 }

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyData.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyData.java
@@ -1,9 +1,10 @@
 package com.ayush.weatherapp.realm.model.forecast;
 
+import com.ayush.weatherapp.realm.RealmDeletable;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 
-public class HourlyData extends RealmObject {
+public class HourlyData extends RealmObject implements RealmDeletable {
   @PrimaryKey private long primaryKey;
   private long time;
   private String summary;
@@ -60,5 +61,9 @@ public class HourlyData extends RealmObject {
 
   public void setApparentTemperature(double apparentTemperature) {
     this.apparentTemperature = apparentTemperature;
+  }
+
+  @Override public void removeFromRealm() {
+    deleteFromRealm();
   }
 }

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyData.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyData.java
@@ -10,7 +10,6 @@ public class HourlyData extends RealmObject implements RealmDeletable {
   private String summary;
   private String icon;
   private double temperature;
-  private double apparentTemperature;
 
   public HourlyData() {
   }
@@ -53,14 +52,6 @@ public class HourlyData extends RealmObject implements RealmDeletable {
 
   public void setTemperature(double temperature) {
     this.temperature = temperature;
-  }
-
-  public double getApparentTemperature() {
-    return apparentTemperature;
-  }
-
-  public void setApparentTemperature(double apparentTemperature) {
-    this.apparentTemperature = apparentTemperature;
   }
 
   @Override public void removeFromRealm() {

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyForecast.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyForecast.java
@@ -53,8 +53,8 @@ public class HourlyForecast extends RealmObject implements RealmDeletable {
 
   @Override public void removeFromRealm() {
     if (hourlyDataList != null) {
-      for (HourlyData hourlyData : hourlyDataList) {
-        hourlyData.removeFromRealm();
+      for (int i = hourlyDataList.size() - 1; i >= 0; i--) {
+        hourlyDataList.get(i).removeFromRealm();
       }
     }
     deleteFromRealm();

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyForecast.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyForecast.java
@@ -4,12 +4,9 @@ import com.ayush.weatherapp.realm.RealmDeletable;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
-import java.util.ArrayList;
 import java.util.List;
 
 public class HourlyForecast extends RealmObject implements RealmDeletable {
-  private static final int MAX_NUMBER_OF_DATA = 6;
-
   @PrimaryKey private long primaryKey;
   private String summary;
   private String icon;
@@ -43,7 +40,7 @@ public class HourlyForecast extends RealmObject implements RealmDeletable {
   }
 
   public List<HourlyData> getHourlyDataList() {
-    return new ArrayList<>(hourlyDataList.subList(0, MAX_NUMBER_OF_DATA));
+    return hourlyDataList;
   }
 
   public void setHourlyDataList(List<HourlyData> hourlyDataList) {

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyForecast.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/forecast/HourlyForecast.java
@@ -1,12 +1,13 @@
 package com.ayush.weatherapp.realm.model.forecast;
 
+import com.ayush.weatherapp.realm.RealmDeletable;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 import java.util.ArrayList;
 import java.util.List;
 
-public class HourlyForecast extends RealmObject {
+public class HourlyForecast extends RealmObject implements RealmDeletable {
   private static final int MAX_NUMBER_OF_DATA = 6;
 
   @PrimaryKey private long primaryKey;
@@ -48,5 +49,14 @@ public class HourlyForecast extends RealmObject {
   public void setHourlyDataList(List<HourlyData> hourlyDataList) {
     this.hourlyDataList = new RealmList<>();
     this.hourlyDataList.addAll(hourlyDataList);
+  }
+
+  @Override public void removeFromRealm() {
+    if (hourlyDataList != null) {
+      for (HourlyData hourlyData : hourlyDataList) {
+        hourlyData.removeFromRealm();
+      }
+    }
+    deleteFromRealm();
   }
 }

--- a/app/src/main/java/com/ayush/weatherapp/realm/model/geocoding/GeoLocation.java
+++ b/app/src/main/java/com/ayush/weatherapp/realm/model/geocoding/GeoLocation.java
@@ -1,9 +1,10 @@
 package com.ayush.weatherapp.realm.model.geocoding;
 
+import com.ayush.weatherapp.realm.RealmDeletable;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
 
-public class GeoLocation extends RealmObject {
+public class GeoLocation extends RealmObject implements RealmDeletable {
   @PrimaryKey private long primaryKey;
   private String location;
   private long createdAt;
@@ -33,5 +34,9 @@ public class GeoLocation extends RealmObject {
 
   public void setLocation(String location) {
     this.location = location;
+  }
+
+  @Override public void removeFromRealm() {
+    deleteFromRealm();
   }
 }

--- a/app/src/main/java/com/ayush/weatherapp/repository/geocoding/GeocodingRepositoryImpl.java
+++ b/app/src/main/java/com/ayush/weatherapp/repository/geocoding/GeocodingRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.ayush.weatherapp.realm.model.geocoding.GeoLocation;
 import com.ayush.weatherapp.utils.DateUtils;
 import io.reactivex.Observable;
 import io.realm.Realm;
+import java.util.List;
 
 public class GeocodingRepositoryImpl implements GeocodingRepository {
   private GeocodingRepository onlineRepository;
@@ -52,7 +53,17 @@ public class GeocodingRepositoryImpl implements GeocodingRepository {
 
   private void saveGeoLocationDetails(GeoLocation geoLocation) {
     Realm realm = RealmUtils.getRealm();
-    realm.executeTransaction(r -> realm.insert(geoLocation));
+    realm.executeTransaction(r -> {
+      // delete all previously saved data and save new data to database
+      List<GeoLocation> storedGeoLocations = r.where(GeoLocation.class).findAll();
+      if (storedGeoLocations != null) {
+        for (GeoLocation storedGeoLocation : storedGeoLocations) {
+          storedGeoLocation.removeFromRealm();
+        }
+      }
+      r.insert(geoLocation);
+    });
+
     realm.close();
   }
 }

--- a/app/src/main/java/com/ayush/weatherapp/repository/weather/WeatherRepositoryImpl.java
+++ b/app/src/main/java/com/ayush/weatherapp/repository/weather/WeatherRepositoryImpl.java
@@ -16,6 +16,7 @@ import com.ayush.weatherapp.utils.UnitConversionUtils;
 import io.reactivex.Observable;
 import io.realm.Realm;
 import java.util.List;
+import timber.log.Timber;
 
 //TODO rename weather to forecast
 public class WeatherRepositoryImpl implements WeatherRepository {
@@ -125,7 +126,19 @@ public class WeatherRepositoryImpl implements WeatherRepository {
 
   private void saveWeatherForecast(Forecast forecast) {
     Realm realm = RealmUtils.getRealm();
-    realm.executeTransaction(r -> realm.insert(forecast));
+
+    realm.executeTransaction(r -> {
+          // delete all previously saved data and save new data to database
+          List<Forecast> storedForecasts = realm.where(Forecast.class).findAll();
+          if (storedForecasts != null) {
+            for (Forecast storedForecast : storedForecasts) {
+              storedForecast.removeFromRealm();
+            }
+          }
+          r.insert(forecast);
+        }
+    );
+
     realm.close();
   }
 }

--- a/app/src/main/java/com/ayush/weatherapp/repository/weather/WeatherRepositoryImpl.java
+++ b/app/src/main/java/com/ayush/weatherapp/repository/weather/WeatherRepositoryImpl.java
@@ -129,7 +129,7 @@ public class WeatherRepositoryImpl implements WeatherRepository {
 
     realm.executeTransaction(r -> {
           // delete all previously saved data and save new data to database
-          List<Forecast> storedForecasts = realm.where(Forecast.class).findAll();
+          List<Forecast> storedForecasts = r.where(Forecast.class).findAll();
           if (storedForecasts != null) {
             for (Forecast storedForecast : storedForecasts) {
               storedForecast.removeFromRealm();

--- a/app/src/main/java/com/ayush/weatherapp/utils/DateUtils.java
+++ b/app/src/main/java/com/ayush/weatherapp/utils/DateUtils.java
@@ -7,7 +7,7 @@ import java.util.Locale;
 import static android.text.format.DateUtils.isToday;
 
 public final class DateUtils {
-  private static final long FIVE_MINUTES = 5 * 60 * 1000;
+  private static final long FIVE_MINUTES = 1 * 30 * 1000;
   private static final String DAY_OF_THE_WEEK = "EE";
   private static final String HH_MM_AA = "hh:mm aa";
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,8 @@
   <string name="location_services_not_enabled">Please enable location services</string>
   <string name="open_location_settings">Open location settings</string>
 
-  <string name="google_places_api_key">AIzaSyDCRsLiCmzX3f4oL5iLJMrhLfe9iOE5o60</string>
+  //use server key
+  <string name="google_places_api_key">AIzaSyAKYfbFODULhRV1rpYhT14xvFC5d_65TNc</string>
   <string name="current_location">Current Location</string>
   <string name="error_heading">It feels terrible.</string>
   <string name="error_subheading">Something went wrong</string>


### PR DESCRIPTION
1. Implement deletable interface for geolocation and forecast realm models.
2. Move store only 8 hourly data logic to mapper.
3. Places api key change.